### PR TITLE
Enable persistent storage via Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,20 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Persisting data with Supabase
+
+This app can store the job source list in a Supabase table. Without these
+settings the list is only kept in your browser's `localStorage`.
+
+1. [Create a Supabase project](https://app.supabase.com/) and copy the **Project URL** and **Anon Key**.
+2. Create a table called `job_sources` with columns:
+   - `id` (text, primary key)
+   - `name` (text)
+   - `url` (text)
+   - `updated_at` (timestamp)
+3. Duplicate `.env.example` to `.env` and fill in `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+   In Lovable you can set these under **Project → Settings → Environment**.
+
+When these variables are provided, edits to the sources list will be saved to
+Supabase and loaded across devices.

--- a/src/services/jobSourcesService.ts
+++ b/src/services/jobSourcesService.ts
@@ -27,6 +27,10 @@ export const updateSourcesInCode = (sources: JobSource[]) => {
 
 // Backend helpers using Supabase
 export const saveSourcesGlobally = async (sources: JobSource[]) => {
+  if (!supabase) {
+    console.warn('Supabase not configured - skipping global save.');
+    return;
+  }
   try {
     const { error } = await supabase
       .from('job_sources')
@@ -46,6 +50,10 @@ export const saveSourcesGlobally = async (sources: JobSource[]) => {
 };
 
 export const loadSourcesGlobally = async (): Promise<JobSource[]> => {
+  if (!supabase) {
+    console.warn('Supabase not configured - returning empty list.');
+    return [];
+  }
   try {
     const { data, error } = await supabase
       .from('job_sources')

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -1,6 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
+// Only create a client when the required env vars exist.
+// This allows the app to run without a backend while still supporting
+// persistent storage when configured.
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey)
+    : null;
+
+if (!supabase) {
+  console.warn('Supabase environment variables are missing. Global persistence is disabled.');
+}


### PR DESCRIPTION
## Summary
- document how to configure Supabase for persistence
- create Supabase client only when env vars are set
- handle missing Supabase configuration in jobSourcesService

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518d11035c832697e7e58ec9259d42