### PR TITLE
Add dark mode toggle to page header

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
+import { Sun, Moon } from "lucide-react"
+import { Switch } from "@/components/ui/switch"
+import { cn } from "@/lib/utils"
+
+interface ThemeToggleProps {
+  className?: string
+}
+
+const ThemeToggle = ({ className }: ThemeToggleProps) => {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Sun className="h-4 w-4" />
+      <Switch
+        checked={isDark}
+        onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+        aria-label="Toggle theme"
+      />
+      <Moon className="h-4 w-4" />
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
+import { ThemeProvider } from 'next-themes'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <App />
+  </ThemeProvider>
+)

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { v4 as uuidv4 } from 'uuid';
-import { Briefcase } from 'lucide-react';
-import JobSourceManager from '@/components/JobSourceManager';
+import { v4 as uuidv4 } from 'uuid'
+import { Briefcase } from 'lucide-react'
+import JobSourceManager from '@/components/JobSourceManager'
+import ThemeToggle from '@/components/ThemeToggle'
 import { loadSourcesGlobally, saveSourcesGlobally, type JobSource } from '@/services/jobSourcesService';
 
 const Index = () => {
@@ -138,7 +139,10 @@ const Index = () => {
       {/* Centered Main Content */}
       <div className="container mx-auto px-4 py-12">
         {/* Header */}
-        <div className="text-center mb-12">
+        <div className="text-center mb-12 relative">
+          <div className="absolute left-4 top-4">
+            <ThemeToggle />
+          </div>
           <div className="flex items-center justify-center space-x-3 space-x-reverse mb-6">
             <div className="w-12 h-12 bg-israel-gradient rounded-xl flex items-center justify-center">
               <Briefcase className="w-7 h-7 text-white" />

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -1,0 +1,9 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey)
+    : null;


### PR DESCRIPTION
## Summary
- accept `className` prop in `ThemeToggle`
- remove global toggle placement in `App`
- render `ThemeToggle` in the Index page header

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_685190355ff88326945a6de12cdd0979