### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.git
+.gitignore
+dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
+COPY . .
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+RUN npm run build
+
+FROM nginx:stable-alpine as production
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ settings the list is only kept in your browser's `localStorage`.
 
 When these variables are provided, edits to the sources list will be saved to
 Supabase and loaded across devices.
+
+
+## Running with Docker
+
+You can build and run the application using Docker. First, copy `.env.example` to `.env` and fill in your Supabase credentials if needed. Then run:
+
+```sh
+docker compose up --build
+```
+
+The application will be available on [http://localhost:3000](http://localhost:3000).
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  web:
+    build:
+      context: .
+      args:
+        VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
+        VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
+    ports:
+      - "3000:80"
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose
- add docker ignore file
- document docker usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685313daeef08326bef72835dc03febb