### PR TITLE
Add Docker build args for DB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.dockerignore
+Dockerfile
+.git
+.gitignore
+npm-debug.log
+
+# Build output
+/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Multi-stage Dockerfile for building and serving the Vite React app
+
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g vite
+
+# Database connection build arguments
+ARG DATABASE_URL
+ARG DB_HOST
+ARG DB_PORT
+ARG DB_NAME
+ARG DB_USER
+ARG DB_PASSWORD
+
+# Set environment variables for runtime
+ENV DATABASE_URL=${DATABASE_URL} \
+    DB_HOST=${DB_HOST} \
+    DB_PORT=${DB_PORT} \
+    DB_NAME=${DB_NAME} \
+    DB_USER=${DB_USER} \
+    DB_PASSWORD=${DB_PASSWORD}
+
+EXPOSE 8080
+CMD ["vite", "preview", "--port", "8080", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -88,3 +88,31 @@ settings the list is only kept in your browser's `localStorage`.
 
 When these variables are provided, edits to the sources list will be saved to
 Supabase and loaded across devices.
+
+## Docker usage
+
+A `Dockerfile` is provided for building the app into a container. The image accepts several build arguments that are passed as environment variables at runtime. These are useful for backend services that may need database access.
+
+Supported build arguments:
+
+- `DATABASE_URL`
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+
+Example build command:
+
+```sh
+docker build \
+  --build-arg DATABASE_URL="postgres://user:pass@host:5432/db" \
+  --build-arg DB_HOST=host \
+  --build-arg DB_PORT=5432 \
+  --build-arg DB_NAME=db \
+  --build-arg DB_USER=user \
+  --build-arg DB_PASSWORD=pass \
+  -t job-seeker .
+```
+
+The resulting container exposes port `8080` running `vite preview`. When backend code is added, it can read the same variables without modifying the Dockerfile.


### PR DESCRIPTION
## Summary
- add Dockerfile with database build arguments
- document Docker usage and environment variables in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853152155e88326a99cbef77cec4b8a