### PR TITLE
Add Supabase local stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
-VITE_SUPABASE_URL=
-VITE_SUPABASE_ANON_KEY=
+# Supabase local credentials
+POSTGRES_PASSWORD=supabase
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+SUPABASE_JWT_SECRET=super-secret-jwt
+
+# Frontend connection details
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiZXhwIjoxNzgxODExNDg3fQ.DP3NXT17rd9dogzk7X1GDNG1-lMxbaxcsMXSAMqCSKU

--- a/README.md
+++ b/README.md
@@ -88,3 +88,27 @@ settings the list is only kept in your browser's `localStorage`.
 
 When these variables are provided, edits to the sources list will be saved to
 Supabase and loaded across devices.
+
+## Running locally with Docker Compose
+
+This repo now includes a `docker-compose.yml` for running Supabase and the
+development server together.
+
+1. Copy `.env.example` to `.env` – the defaults are suitable for local testing.
+2. Start the stack:
+
+   ```sh
+   docker compose up
+   ```
+
+   The REST API will be available on <http://localhost:54321> and Postgres on
+   `localhost:54322`.
+
+3. The frontend will start on <http://localhost:5173>.
+
+The anonymous API key used by the app is stored in `.env` as
+`VITE_SUPABASE_ANON_KEY`. To print it from a running container you can use:
+
+```sh
+docker compose exec web printenv VITE_SUPABASE_ANON_KEY
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.9'
+
+services:
+  db:
+    image: supabase/postgres:15
+    restart: unless-stopped
+    ports:
+      - "54322:5432"
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-supabase}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+    networks:
+      - supabase
+
+  auth:
+    image: supabase/gotrue:v2
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-supabase}@db:5432/${POSTGRES_DB:-postgres}
+      GOTRUE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-super-secret-jwt}
+      GOTRUE_SITE_URL: http://localhost:54321
+      API_EXTERNAL_URL: http://localhost:54321/auth/v1
+    networks:
+      - supabase
+
+  rest:
+    image: postgrest/postgrest:v12
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-supabase}@db:5432/${POSTGRES_DB:-postgres}
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${SUPABASE_JWT_SECRET:-super-secret-jwt}
+    ports:
+      - "54321:3000"
+    networks:
+      - supabase
+
+  web:
+    image: node:20
+    working_dir: /app
+    command: npm run dev -- --host 0.0.0.0
+    volumes:
+      - ./:/app
+    ports:
+      - "5173:5173"
+    environment:
+      VITE_SUPABASE_URL: http://localhost:54321
+      VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
+    depends_on:
+      - rest
+    networks:
+      - supabase
+
+networks:
+  supabase:


### PR DESCRIPTION
## Summary
- add docker compose with Supabase services and the dev server
- provide default Supabase env vars
- document the compose workflow and anon key retrieval in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853151f532c8326a7f2390748966d93