### PR TITLE
Add draggable colored source icons

### DIFF
--- a/src/components/JobSourceManager.tsx
+++ b/src/components/JobSourceManager.tsx
@@ -6,7 +6,7 @@ import { ExternalLink, Plus, Edit, Trash2, Lock } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { useToast } from '@/hooks/use-toast';
 import SourceCodeUpdater from './SourceCodeUpdater';
-import GlassIcons from './reactbits/GlassIcons';
+import GlassIcons, { GlassIconsItem } from './reactbits/GlassIcons';
 
 interface JobSource {
   id: string;
@@ -122,6 +122,15 @@ const JobSourceManager: React.FC<JobSourceManagerProps> = ({ sources, onSourcesC
     setNewSource({ name: '', url: '' });
   };
 
+  const handleReorder = (items: GlassIconsItem[]) => {
+    const newSources = items.map((item) => {
+      return sources.find((s) => s.id === item.id)!;
+    });
+    setEditingSources(newSources);
+    onSourcesChange(newSources);
+    setHasChanges(true);
+  };
+
   return (
     <div>
       <Card className="mb-6">
@@ -228,6 +237,7 @@ const JobSourceManager: React.FC<JobSourceManagerProps> = ({ sources, onSourcesC
           ) : (
             <GlassIcons
               items={sources.map((source, idx) => ({
+                id: source.id,
                 icon: <ExternalLink className="w-4 h-4" />,
                 color: ["blue", "purple", "red", "indigo", "orange", "green"][
                   idx % 6
@@ -235,6 +245,8 @@ const JobSourceManager: React.FC<JobSourceManagerProps> = ({ sources, onSourcesC
                 label: source.name,
                 href: source.url,
               }))}
+              reorderable
+              onReorder={handleReorder}
             />
           )}
         </CardContent>

--- a/src/components/reactbits/GlassIcons.tsx
+++ b/src/components/reactbits/GlassIcons.tsx
@@ -1,6 +1,13 @@
 import React from "react";
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult,
+} from "react-beautiful-dnd";
 
 export interface GlassIconsItem {
+  id: string;
   icon: React.ReactElement;
   color: string;
   label: string;
@@ -11,6 +18,8 @@ export interface GlassIconsItem {
 export interface GlassIconsProps {
   items: GlassIconsItem[];
   className?: string;
+  reorderable?: boolean;
+  onReorder?: (items: GlassIconsItem[]) => void;
 }
 
 const gradientMapping: Record<string, string> = {
@@ -22,7 +31,12 @@ const gradientMapping: Record<string, string> = {
   green: "linear-gradient(hsl(123, 90%, 40%), hsl(108, 90%, 40%))",
 };
 
-const GlassIcons: React.FC<GlassIconsProps> = ({ items, className }) => {
+const GlassIcons: React.FC<GlassIconsProps> = ({
+  items,
+  className,
+  reorderable,
+  onReorder,
+}) => {
   const getBackgroundStyle = (color: string): React.CSSProperties => {
     if (gradientMapping[color]) {
       return { background: gradientMapping[color] };
@@ -30,55 +44,81 @@ const GlassIcons: React.FC<GlassIconsProps> = ({ items, className }) => {
     return { background: color };
   };
 
-  return (
-    <div
-      className={`grid gap-[5em] grid-cols-2 md:grid-cols-3 mx-auto py-[3em] overflow-visible ${
-        className || ""
-      }`}
-    >
-      {items.map((item, index) => {
-        const Wrapper = item.href ? 'a' : 'button';
-        const wrapperProps = item.href
-          ? { href: item.href, target: '_blank', rel: 'noopener noreferrer' }
-          : { type: 'button' };
-        return (
-          <Wrapper
-            key={index}
-            aria-label={item.label}
-            className={`relative bg-transparent outline-none w-[4.5em] h-[4.5em] [perspective:24em] [transform-style:preserve-3d] [-webkit-tap-highlight-color:transparent] group ${
-              item.customClass || ""
-            }`}
-            {...wrapperProps}
-          >
-          <span
-            className="absolute top-0 left-0 w-full h-full rounded-[1.25em] block transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.83,0,0.17,1)] origin-[100%_100%] rotate-[15deg] group-hover:[transform:rotate(25deg)_translate3d(-0.5em,-0.5em,0.5em)]"
-            style={{
-              ...getBackgroundStyle(item.color),
-              boxShadow: "0.5em -0.5em 0.75em hsla(223, 10%, 10%, 0.15)",
-            }}
-          ></span>
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination || !onReorder) return;
+    const updated = Array.from(items);
+    const [removed] = updated.splice(result.source.index, 1);
+    updated.splice(result.destination.index, 0, removed);
+    onReorder(updated);
+  };
 
-          <span
-            className="absolute top-0 left-0 w-full h-full rounded-[1.25em] bg-[hsla(0,0%,100%,0.15)] transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.83,0,0.17,1)] origin-[80%_50%] flex backdrop-blur-[0.75em] [-webkit-backdrop-filter:blur(0.75em)] transform group-hover:[transform:translateZ(2em)]"
-            style={{
-              boxShadow: "0 0 0 0.1em hsla(0, 0%, 100%, 0.3) inset",
-            }}
-          >
-            <span
-              className="m-auto w-[1.5em] h-[1.5em] flex items-center justify-center"
-              aria-hidden="true"
-            >
-              {item.icon}
-            </span>
-          </span>
+  const renderItem = (item: GlassIconsItem, index: number) => {
+    const Wrapper = item.href ? 'a' : 'button';
+    const wrapperProps = item.href
+      ? { href: item.href, target: '_blank', rel: 'noopener noreferrer' }
+      : { type: 'button' };
+    const element = (
+      <Wrapper
+        key={item.id}
+        aria-label={item.label}
+        className={`relative bg-transparent outline-none w-[3.5em] h-[3.5em] [perspective:24em] [transform-style:preserve-3d] [-webkit-tap-highlight-color:transparent] transition-transform duration-200 hover:-translate-y-1 group ${
+          item.customClass || ""
+        }`}
+        {...wrapperProps}
+      >
+        <span
+          className="absolute top-0 left-0 w-full h-full rounded-[1.25em] block transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.83,0,0.17,1)] origin-[100%_100%] rotate-[15deg] group-hover:[transform:rotate(25deg)_translate3d(-0.5em,-0.5em,0.5em)]"
+          style={{
+            ...getBackgroundStyle(item.color),
+            boxShadow: "0.5em -0.5em 0.75em hsla(223, 10%, 10%, 0.15)",
+          }}
+        ></span>
 
-          <span className="absolute top-full left-0 right-0 text-center whitespace-nowrap leading-[2] text-base opacity-0 transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.83,0,0.17,1)] translate-y-0 group-hover:opacity-100 group-hover:[transform:translateY(20%)]">
-            {item.label}
+        <span
+          className="absolute top-0 left-0 w-full h-full rounded-[1.25em] bg-[hsla(0,0%,100%,0.15)] transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.83,0,0.17,1)] origin-[80%_50%] flex backdrop-blur-[0.75em] [-webkit-backdrop-filter:blur(0.75em)] transform group-hover:[transform:translateZ(2em)]"
+          style={{
+            boxShadow: "0 0 0 0.1em hsla(0, 0%, 100%, 0.3) inset",
+          }}
+        >
+          <span
+            className="m-auto w-[1.5em] h-[1.5em] flex items-center justify-center"
+            aria-hidden="true"
+          >
+            {item.icon}
           </span>
-          </Wrapper>
-        );
-      })}
-    </div>
+        </span>
+
+        <span className="absolute top-full left-0 right-0 text-center whitespace-nowrap leading-[2] text-sm text-blue-600">
+          {item.label}
+        </span>
+      </Wrapper>
+    );
+    return element;
+  };
+
+  const gridClasses = `grid grid-cols-3 gap-4 mx-auto py-6 overflow-visible ${className || ""}`;
+
+  return reorderable && onReorder ? (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Droppable droppableId="icons">
+        {(provided) => (
+          <div ref={provided.innerRef} {...provided.droppableProps} className={gridClasses}>
+            {items.map((item, index) => (
+              <Draggable key={item.id} draggableId={item.id} index={index}>
+                {(drag) => (
+                  <div ref={drag.innerRef} {...drag.draggableProps} {...drag.dragHandleProps}>
+                    {renderItem(item, index)}
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  ) : (
+    <div className={gridClasses}>{items.map(renderItem)}</div>
   );
 };
 


### PR DESCRIPTION
## Summary
- update GlassIcons to support reordering with react-beautiful-dnd
- shrink icon size, keep labels visible and colored
- use new reorder option in JobSourceManager

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853c400cffc8326ab7974cf0777740f