### PR TITLE
Integrate click-spark effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 
   <body>
     <div id="root"></div>
+    <click-spark></click-spark>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@supabase/supabase-js": "^2.50.0",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
+        "click-spark": "^2.1.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -3618,6 +3619,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/click-spark": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/click-spark/-/click-spark-2.1.0.tgz",
+      "integrity": "sha512-/Jd1gPnMT6hqlkhARg+3Dh3Ziqf0enMSMovwgykLx6sQrgurg2/YiomHNAhLuRHB8qmcjWw1ch0yc+mreqctHg==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
+    "click-spark": "^2.1.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import 'click-spark'
 
 createRoot(document.getElementById('root')!).render(
   <App />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    'click-spark': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add click-spark dependency
- import click-spark and register the web component
- declare the `click-spark` element type
- mount `<click-spark>` in the document

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ca5e08d48326ab52cd7bed21fef0