### PR TITLE
Add glare effect to source icons

### DIFF
--- a/src/components/reactbits/GlassIcons.tsx
+++ b/src/components/reactbits/GlassIcons.tsx
@@ -88,6 +88,10 @@ const GlassIcons: React.FC<GlassIconsProps> = ({
           </span>
         </span>
 
+        <span className="pointer-events-none absolute inset-0 rounded-[1.25em] overflow-hidden">
+          <span className="absolute left-[-100%] top-0 w-[120%] h-full bg-white/40 opacity-0 rotate-45 group-hover:animate-glare" />
+        </span>
+
         <span className="absolute top-full left-0 right-0 text-center whitespace-nowrap leading-[2] text-sm text-blue-600">
           {item.label}
         </span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,23 +100,35 @@ export default {
 						transform: 'translateY(0)'
 					}
 				},
-				'slide-up': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateY(20px)'
-					},
-					'100%': {
-						opacity: '1',
-						transform: 'translateY(0)'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'fade-in': 'fade-in 0.6s ease-out',
-				'slide-up': 'slide-up 0.4s ease-out'
-			},
+                                'slide-up': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateY(20px)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'translateY(0)'
+                                        }
+                                },
+                                'glare': {
+                                        '0%': {
+                                                transform: 'translateX(-100%) rotate(45deg)',
+                                                opacity: '0'
+                                        },
+                                        '50%': { opacity: '0.5' },
+                                        '100%': {
+                                                transform: 'translateX(100%) rotate(45deg)',
+                                                opacity: '0'
+                                        }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
+                                'fade-in': 'fade-in 0.6s ease-out',
+                                'slide-up': 'slide-up 0.4s ease-out',
+                                'glare': 'glare 0.75s linear'
+                        },
 			backgroundImage: {
 				'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
 				'israel-gradient': 'linear-gradient(135deg, #2563eb 0%, #0038b8 50%, #ff6b35 100%)'


### PR DESCRIPTION
## Summary
- animate a glare overlay when hovering over source icons
- add `glare` keyframes and animation to Tailwind config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ca821028832686d2062d91198f19