### PR TITLE
Create lanyard-style header

### DIFF
--- a/src/components/LanyardHeader.tsx
+++ b/src/components/LanyardHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import DecayCard from '@/components/reactbits/DecayCard';
+
+/**
+ * Displays the main header using a single DecayCard where the
+ * title and sub header are split to opposite sides of the card.
+ */
+const LanyardHeader: React.FC = () => {
+  return (
+    <DecayCard
+      width={600}
+      height={400}
+      image="https://picsum.photos/600/400?grayscale"
+      contentClassName="!p-4 w-[calc(100%-2em)]"
+    >
+      <div className="flex w-full justify-between items-end gap-4">
+        <span className="font-black text-[2.5rem] leading-tight first-line:text-[6rem] text-right">
+          MechJobs IL
+        </span>
+        <span className="font-semibold text-xl leading-tight text-left">
+          מציאת עבודות לסטודנטים להנדסת מכונות בישראל
+          <br />
+          היעד האחד שלך לגילוי הזדמנויות בחברות הישראליות המובילות
+        </span>
+      </div>
+    </DecayCard>
+  );
+};
+
+export default LanyardHeader;

--- a/src/components/reactbits/DecayCard.tsx
+++ b/src/components/reactbits/DecayCard.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect, useRef, ReactNode } from "react";
 import { gsap } from "gsap";
+import { cn } from "@/lib/utils";
 
 interface DecayCardProps {
   width?: number;
   height?: number;
   image?: string;
   children?: ReactNode;
+  /**
+   * Additional class names for the content wrapper so consumers can
+   * customize the layout of the overlaid content.
+   */
+  contentClassName?: string;
 }
 
 const DecayCard: React.FC<DecayCardProps> = ({
@@ -13,6 +19,7 @@ const DecayCard: React.FC<DecayCardProps> = ({
   height = 400,
   image = "https://picsum.photos/300/400?grayscale",
   children,
+  contentClassName,
 }) => {
   const svgRef = useRef<HTMLDivElement | null>(null);
   const displacementMapRef = useRef<SVGFEDisplacementMapElement | null>(null);
@@ -174,7 +181,12 @@ const DecayCard: React.FC<DecayCardProps> = ({
           />
         </g>
       </svg>
-      <div className="absolute bottom-[1.2em] left-[1em] tracking-[-0.5px] font-black text-[2.5rem] leading-[1.5em] first-line:text-[6rem]">
+      <div
+        className={cn(
+          "absolute bottom-[1.2em] left-[1em] tracking-[-0.5px] font-black text-[2.5rem] leading-[1.5em] first-line:text-[6rem]",
+          contentClassName
+        )}
+      >
         {children}
       </div>
     </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import DecayCard from '@/components/reactbits/DecayCard';
 import RotatingText from '@/components/reactbits/RotatingText';
+import LanyardHeader from '@/components/LanyardHeader';
 import JobSourceManager from '@/components/JobSourceManager';
 import { loadSourcesGlobally, saveSourcesGlobally, type JobSource } from '@/services/jobSourcesService';
 import { isUsingDatabase } from '@/services/supabaseClient';
@@ -127,21 +127,7 @@ const Index = () => {
       <div className="container mx-auto px-4 py-12">
         {/* Header */}
         <div className="text-center mb-12 flex flex-col items-center gap-6">
-          <DecayCard width={600} height={400} image="https://picsum.photos/600/400?grayscale">
-            MechJobs IL
-          </DecayCard>
-
-          <DecayCard
-            width={600}
-            height={250}
-            image="https://picsum.photos/600/250?grayscale"
-          >
-            <>
-              מציאת עבודות לסטודנטים להנדסת מכונות בישראל
-              <br />
-              היעד האחד שלך לגילוי הזדמנויות בחברות הישראליות המובילות
-            </>
-          </DecayCard>
+          <LanyardHeader />
           <RotatingText
             texts={["שלחת קורות חיים היום ?"]}
             className="text-xl font-semibold text-gray-800"


### PR DESCRIPTION
## Summary
- allow customizing DecayCard content positioning
- add `LanyardHeader` component to combine title and subtitle
- use the new component on the index page

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853d0c96fb4832690a1baf63b47b7e2