### PR TITLE
Add Discord presence via Lanyard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "use-lanyard": "^1.7.0",
         "uuid": "^11.1.0",
         "vaul": "^0.9.3",
         "zod": "^3.23.8"
@@ -912,6 +913,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@prequist/lanyard": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prequist/lanyard/-/lanyard-1.1.0.tgz",
+      "integrity": "sha512-OBBRIoFQZgDF2t7/MBUw35YYmwOU9WAVvvvLHQHrwOw0JrCuTpsl1OI9kSjGjOfsqhB2cHIGYQg5nYPkOsg9nw=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
@@ -7282,6 +7288,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-lanyard": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/use-lanyard/-/use-lanyard-1.7.0.tgz",
+      "integrity": "sha512-QtZaNugdA49GTjXJDTKM7E0hJNvbd4JavnKDi4zWelrdZAbypuHSd6B5gM4w14DGSkvr3z5DEJA85t74FAK1lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@prequist/lanyard": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/use-memo-one": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "use-lanyard": "^1.7.0",
     "uuid": "^11.1.0",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"

--- a/src/components/DiscordPresence.tsx
+++ b/src/components/DiscordPresence.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useLanyardWS } from 'use-lanyard';
+
+interface DiscordPresenceProps {
+  userId: string;
+}
+
+const DiscordPresence: React.FC<DiscordPresenceProps> = ({ userId }) => {
+  const data = useLanyardWS(userId);
+
+  if (!data) return null;
+
+  return (
+    <div className="text-sm text-gray-600">
+      דיסקורד: {data.discord_status}
+      {data.spotify && (
+        <div>
+          מאזין ל‎{data.spotify.song} מאת {data.spotify.artist}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DiscordPresence;

--- a/src/components/LanyardHeader.tsx
+++ b/src/components/LanyardHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import DecayCard from '@/components/reactbits/DecayCard';
+import DiscordPresence from '@/components/DiscordPresence';
 
 /**
  * Displays the main header using a single DecayCard where the
@@ -13,15 +14,16 @@ const LanyardHeader: React.FC = () => {
       image="https://picsum.photos/600/400?grayscale"
       contentClassName="!p-4 w-[calc(100%-2em)]"
     >
-      <div className="flex w-full justify-between items-end gap-4">
+      <div className="flex w-full flex-col gap-2 items-end">
         <span className="font-black text-[2.5rem] leading-tight first-line:text-[6rem] text-right">
           MechJobs IL
         </span>
-        <span className="font-semibold text-xl leading-tight text-left">
+        <span className="font-semibold text-xl leading-tight text-right">
           מציאת עבודות לסטודנטים להנדסת מכונות בישראל
           <br />
           היעד האחד שלך לגילוי הזדמנויות בחברות הישראליות המובילות
         </span>
+        <DiscordPresence userId="268798547439255572" />
       </div>
     </DecayCard>
   );


### PR DESCRIPTION
## Summary
- display Discord presence with use-lanyard
- show presence info inside `LanyardHeader`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853d26930ac83269a4117f2a42d876c