### PR TITLE
Remove outdated job sources

### DIFF
--- a/public/data/job-sources.json
+++ b/public/data/job-sources.json
@@ -1,21 +1,79 @@
 {
   "jobSources": [
-    {"id": "1", "name": "LinkedIn", "url": "https://www.linkedin.com/jobs/search/?currentJobId=4235127935&f_JT=I&geoId=101620260&keywords=mechanical%20engineer%20student&origin=JOB_SEARCH_PAGE_LOCATION_AUTOCOMPLETE&originalSubdomain=il&refresh=true"},
-    {"id": "2", "name": "Glassdoor", "url": "https://www.glassdoor.com/Job/israel-mechanical-engineering-student-jobs-SRCH_IL.0,6_IN119_KO7,37.htm"},
-    {"id": "3", "name": "AllJobs", "url": "https://www.alljobs.co.il/SearchResultsGuest.aspx?page=1&position=1047&type=&source=&duration=0&exc=&region="},
-    {"id": "4", "name": "JobMaster", "url": "https://www.jobmaster.co.il/jobs/?q=מהנדס%20מכונות%20סטודנט&l="},
-    {"id": "5", "name": "Drushim", "url": "https://www.drushim.co.il/jobs/?searchterm=מהנדס%20מכונות%20סטודנט"},
-    {"id": "7", "name": "SQLink", "url": "https://www.sqlink.com/career?search=engineering%20intern&type=internship"},
-    {"id": "8", "name": "Intel Israel", "url": "https://jobs.intel.com/en_US/search?keywords=engineering%20intern&location=Israel"},
-    {"id": "9", "name": "Elbit Systems", "url": "https://elbitsystemscareer.com/go/סטודנטים/9275855/"},
-    {"id": "10", "name": "IAI (אלתא)", "url": "https://jobs.iai.co.il/jobs/?tp=משרת%20סטודנט"},
-    {"id": "11", "name": "רפאל (Rafael)", "url": "https://career.rafael.co.il/students/"},
-    {"id": "12", "name": "HP Careers", "url": "https://jobs.hp.com/us/students-graduates/"},
-    {"id": "13", "name": "Applied Materials", "url": "https://jobs.appliedmaterials.com/location/israel-jobs/95/294640?q=student"},
-    {"id": "14", "name": "Art Medical", "url": "https://artmedical.com/careers/?search=intern"},
-    {"id": "15", "name": "Arad Technologies", "url": "https://aradtec.com/careers/?search=student"},
-    {"id": "16", "name": "Ness Technologies", "url": "https://www.ness.com/careers/?search=intern"},
-    {"id": "17", "name": "Amarel", "url": "https://www.amarel.net/careers-tags/students/"},
-    {"id": "18", "name": "TAT Technologies", "url": "https://apply.workable.com/tat-technologies-ltd/"}
+    {
+      "id": "2",
+      "name": "Glassdoor",
+      "url": "https://www.glassdoor.com/Job/israel-mechanical-engineering-student-jobs-SRCH_IL.0,6_IN119_KO7,37.htm"
+    },
+    {
+      "id": "4",
+      "name": "JobMaster",
+      "url": "https://www.jobmaster.co.il/jobs/?q=מהנדס%20מכונות%20סטודנט&l="
+    },
+    {
+      "id": "5",
+      "name": "Drushim",
+      "url": "https://www.drushim.co.il/jobs/?searchterm=מהנדס%20מכונות%20סטודנט"
+    },
+    {
+      "id": "7",
+      "name": "SQLink",
+      "url": "https://www.sqlink.com/career?search=engineering%20intern&type=internship"
+    },
+    {
+      "id": "8",
+      "name": "Intel Israel",
+      "url": "https://jobs.intel.com/en_US/search?keywords=engineering%20intern&location=Israel"
+    },
+    {
+      "id": "9",
+      "name": "Elbit Systems",
+      "url": "https://elbitsystemscareer.com/go/סטודנטים/9275855/"
+    },
+    {
+      "id": "10",
+      "name": "IAI (אלתא)",
+      "url": "https://jobs.iai.co.il/jobs/?tp=משרת%20סטודנט"
+    },
+    {
+      "id": "11",
+      "name": "רפאל (Rafael)",
+      "url": "https://career.rafael.co.il/students/"
+    },
+    {
+      "id": "12",
+      "name": "HP Careers",
+      "url": "https://jobs.hp.com/us/students-graduates/"
+    },
+    {
+      "id": "13",
+      "name": "Applied Materials",
+      "url": "https://jobs.appliedmaterials.com/location/israel-jobs/95/294640?q=student"
+    },
+    {
+      "id": "14",
+      "name": "Art Medical",
+      "url": "https://artmedical.com/careers/?search=intern"
+    },
+    {
+      "id": "15",
+      "name": "Arad Technologies",
+      "url": "https://aradtec.com/careers/?search=student"
+    },
+    {
+      "id": "16",
+      "name": "Ness Technologies",
+      "url": "https://www.ness.com/careers/?search=intern"
+    },
+    {
+      "id": "17",
+      "name": "Amarel",
+      "url": "https://www.amarel.net/careers-tags/students/"
+    },
+    {
+      "id": "18",
+      "name": "TAT Technologies",
+      "url": "https://apply.workable.com/tat-technologies-ltd/"
+    }
   ]
 }

--- a/src/lib/sourceIcons.tsx
+++ b/src/lib/sourceIcons.tsx
@@ -1,9 +1,7 @@
 import { LucideIcon, ExternalLink, Linkedin, Search, Briefcase, BadgeCheck, Link2, Cpu, Shield, Plane, Rocket, MonitorUp, Factory, Stethoscope, Wrench, Building2, Users, Hammer } from 'lucide-react';
 
 const sourceIconMap: Record<string, LucideIcon> = {
-  LinkedIn: Linkedin,
   Glassdoor: Search,
-  AllJobs: Briefcase,
   JobMaster: BadgeCheck,
   Drushim: Search,
   SQLink: Link2,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,19 +8,9 @@ import { isUsingDatabase } from '@/services/supabaseClient';
 const Index = () => {
   const defaultSources = [
     {
-      id: '1',
-      name: 'LinkedIn',
-      url: 'https://www.linkedin.com/jobs/search/?currentJobId=4235127935&f_JT=I&geoId=101620260&keywords=mechanical%20engineer%20student&origin=JOB_SEARCH_PAGE_LOCATION_AUTOCOMPLETE&originalSubdomain=il&refresh=true',
-    },
-    {
       id: '2',
       name: 'Glassdoor',
       url: 'https://www.glassdoor.com/Job/israel-mechanical-engineering-student-jobs-SRCH_IL.0,6_IN119_KO7,37.htm',
-    },
-    {
-      id: '3',
-      name: 'AllJobs',
-      url: 'https://www.alljobs.co.il/SearchResultsGuest.aspx?page=1&position=1047&type=&source=&duration=0&exc=&region=',
     },
     {
       id: '4',


### PR DESCRIPTION
## Summary
- remove LinkedIn and AllJobs listings from default source list
- clean icon map entries for these sources
- update bundled job sources JSON

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853d4be6ea883268127e8822c326c1f