### PR TITLE
Fix header text visibility

### DIFF
--- a/src/components/LanyardHeader.tsx
+++ b/src/components/LanyardHeader.tsx
@@ -14,7 +14,7 @@ const LanyardHeader: React.FC = () => {
       image="https://picsum.photos/600/400?grayscale"
       contentClassName="!p-4 w-[calc(100%-2em)]"
     >
-      <div className="flex w-full flex-col gap-2 items-end">
+      <div className="flex w-full flex-col gap-2 items-end text-white">
         <span className="font-black text-[2.5rem] leading-tight first-line:text-[6rem] text-right">
           MechJobs IL
         </span>


### PR DESCRIPTION
## Summary
- ensure header text is visible on the dark image by making it white

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853d4dcfc8c832687dedb41165296e4