### PR TITLE
Add plus icon for new job source

### DIFF
--- a/src/components/JobSourceManager.tsx
+++ b/src/components/JobSourceManager.tsx
@@ -238,16 +238,26 @@ const JobSourceManager: React.FC<JobSourceManagerProps> = ({ sources, onSourcesC
           ) : (
             <div className="w-full">
               <GlassIcons
-                items={sources.map((source, idx) => {
-                  const IconComponent = getSourceIcon(source.name);
-                  return {
-                    id: source.id,
-                    icon: <IconComponent className="w-6 h-6 text-white" />,
-                    color: ["blue", "purple", "red", "indigo", "orange", "green"][idx % 6],
-                    label: source.name,
-                    href: source.url,
-                  };
-                })}
+                items={[
+                  ...sources.map((source, idx) => {
+                    const IconComponent = getSourceIcon(source.name);
+                    return {
+                      id: source.id,
+                      icon: <IconComponent className="w-6 h-6 text-white" />,
+                      color: ["blue", "purple", "red", "indigo", "orange", "green"][idx % 6],
+                      label: source.name,
+                      href: source.url,
+                    };
+                  }),
+                  {
+                    id: 'add-source',
+                    icon: <Plus className="w-6 h-6 text-white" />,
+                    color: 'indigo',
+                    label: 'הוסף מקור',
+                    onClick: handleManageClick,
+                    customClass: 'cursor-pointer',
+                  },
+                ]}
                 reorderable={isAuthenticated}
                 onReorder={handleReorder}
                 className="max-w-4xl mx-auto"

--- a/src/components/reactbits/GlassIcons.tsx
+++ b/src/components/reactbits/GlassIcons.tsx
@@ -16,6 +16,7 @@ export interface GlassIconsItem {
   label: string;
   href?: string;
   customClass?: string;
+  onClick?: () => void;
 }
 
 export interface GlassIconsProps {
@@ -108,6 +109,7 @@ const GlassIcons: React.FC<GlassIconsProps> = ({
           rel="noopener noreferrer"
           aria-label={item.label}
           className={commonClasses}
+          onClick={item.onClick}
         >
           {content}
         </a>
@@ -120,6 +122,7 @@ const GlassIcons: React.FC<GlassIconsProps> = ({
         type="button"
         aria-label={item.label}
         className={commonClasses}
+        onClick={item.onClick}
       >
         {content}
       </button>


### PR DESCRIPTION
## Summary
- allow `GlassIcons` items to register click handlers
- show an `add-source` icon alongside job source icons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853d63137408326b3d27fecef86c973