### PR TITLE
Fix icon matching logic

### DIFF
--- a/src/lib/sourceIcons.tsx
+++ b/src/lib/sourceIcons.tsx
@@ -1,25 +1,49 @@
-import { LucideIcon, ExternalLink, Linkedin, Search, Briefcase, BadgeCheck, Link2, Cpu, Shield, Plane, Rocket, MonitorUp, Factory, Stethoscope, Wrench, Building2, Users, Hammer } from 'lucide-react';
+import {
+  LucideIcon,
+  ExternalLink,
+  Linkedin,
+  Search,
+  Briefcase,
+  BadgeCheck,
+  Link2,
+  Cpu,
+  Shield,
+  Plane,
+  Rocket,
+  MonitorUp,
+  Factory,
+  Stethoscope,
+  Wrench,
+  Building2,
+  Users,
+  Hammer,
+} from 'lucide-react';
+
+const normalizeName = (name: string) =>
+  name.toLowerCase().replace(/[^a-z0-9\u0590-\u05ff]+/g, '');
 
 const sourceIconMap: Record<string, LucideIcon> = {
-  LinkedIn: Linkedin,
-  Glassdoor: Search,
-  AllJobs: Briefcase,
-  JobMaster: BadgeCheck,
-  Drushim: Search,
-  SQLink: Link2,
-  'Intel Israel': Cpu,
-  'Elbit Systems': Shield,
-  'IAI (אלתא)': Plane,
-  'רפאל (Rafael)': Rocket,
-  'HP Careers': MonitorUp,
-  'Applied Materials': Factory,
-  'Art Medical': Stethoscope,
-  'Arad Technologies': Wrench,
-  'Ness Technologies': Building2,
-  Amarel: Users,
-  'TAT Technologies': Hammer,
+  linkedin: Linkedin,
+  glassdoor: Search,
+  alljobs: Briefcase,
+  jobmaster: BadgeCheck,
+  drushim: Search,
+  sqlink: Link2,
+  intelisrael: Cpu,
+  elbitsystems: Shield,
+  iaiאלתא: Plane,
+  רפאלrafael: Rocket,
+  hpcareers: MonitorUp,
+  appliedmaterials: Factory,
+  artmedical: Stethoscope,
+  aradtechnologies: Wrench,
+  nesstechnologies: Building2,
+  amarel: Users,
+  tattechnologies: Hammer,
+  tat: Hammer,
 };
 
 export const getSourceIcon = (name: string): LucideIcon => {
-  return sourceIconMap[name] || ExternalLink;
+  const normalized = normalizeName(name);
+  return sourceIconMap[normalized] || ExternalLink;
 };


### PR DESCRIPTION
## Summary
- normalize job source names before mapping to icons
- expand icon map to cover normalized names

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853d7427ec083269f49a160cb7e3b9b