### PR TITLE
Add visit counter to footer

### DIFF
--- a/src/hooks/useVisitCount.ts
+++ b/src/hooks/useVisitCount.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'visitCount';
+
+export default function useVisitCount() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const stored = Number(localStorage.getItem(STORAGE_KEY) || '0');
+    const updated = stored + 1;
+    localStorage.setItem(STORAGE_KEY, String(updated));
+    setCount(updated);
+  }, []);
+
+  return count;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import useVisitCount from '@/hooks/useVisitCount';
 import RotatingText from '@/components/reactbits/RotatingText';
 import LanyardHeader from '@/components/LanyardHeader';
 import JobSourceManager from '@/components/JobSourceManager';
@@ -103,6 +104,7 @@ const Index = () => {
 
 
   const [jobSources, setJobSources] = useState(defaultSources);
+  const visits = useVisitCount();
 
   useEffect(() => {
     loadSourcesGlobally()
@@ -145,6 +147,9 @@ const Index = () => {
         <div className="relative text-center mt-16 pt-8 border-t border-gray-200">
           <span className="absolute left-4 text-xs text-gray-500">
             {isUsingDatabase ? 'DB' : 'Local'}
+          </span>
+          <span className="absolute right-4 text-xs text-gray-500">
+            {visits} visits
           </span>
           <p className="text-tech-gray">© 2025 MechJobs IL מאת ליאור כהן עבור ליאור כהן - מחבר סטודנטים להנדסת מכונות עם הזדמנויות</p>
         </div>


### PR DESCRIPTION
## Summary
- show a simple visit count in the footer of the Index page
- track visits per user using localStorage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853dbe059cc8326a244d4ee24e5ca4d