### PR TITLE
Refactor header using animated lanyard

### DIFF
--- a/src/components/LanyardHeader.tsx
+++ b/src/components/LanyardHeader.tsx
@@ -1,31 +1,31 @@
 import React from 'react';
-import DecayCard from '@/components/reactbits/DecayCard';
-import DiscordPresence from '@/components/DiscordPresence';
+import Lanyard from '@/components/reactbits/Lanyard';
+import ShinyButton from '@/components/reactbits/ShinyButton';
+import { Checkbox } from '@/components/ui/checkbox';
 
-/**
- * Displays the main header using a single DecayCard where the
- * title and sub header are split to opposite sides of the card.
- */
 const LanyardHeader: React.FC = () => {
   return (
-    <DecayCard
-      width={600}
-      height={400}
-      image="https://picsum.photos/600/400?grayscale"
-      contentClassName="!p-4 w-[calc(100%-2em)]"
-    >
-      <div className="flex w-full flex-col gap-2 items-end text-white">
-        <span className="font-black text-[2.5rem] leading-tight first-line:text-[6rem] text-right">
-          MechJobs IL
-        </span>
-        <span className="font-semibold text-xl leading-tight text-right">
-          מציאת עבודות לסטודנטים להנדסת מכונות בישראל
-          <br />
-          היעד האחד שלך לגילוי הזדמנויות בחברות הישראליות המובילות
-        </span>
-        <DiscordPresence userId="268798547439255572" />
+    <Lanyard cardClassName="w-[22rem] sm:w-[28rem]">
+      <div className="p-4 flex flex-col items-center gap-4 text-center">
+        <div className="flex flex-col gap-2">
+          <span className="font-black text-[2rem] sm:text-[2.5rem] leading-tight">
+            MechJobs IL
+          </span>
+          <span className="font-semibold text-sm sm:text-lg leading-tight">
+            מציאת עבודות לסטודנטים להנדסת מכונות בישראל
+            <br />
+            היעד האחד שלך לכל הזדמנויות בחברות הישראליות המובילות
+          </span>
+        </div>
+        <div className="flex items-center justify-center gap-2">
+          <ShinyButton>שלחתי היום!</ShinyButton>
+          <Checkbox
+            defaultChecked
+            className="data-[state=checked]:bg-green-600 data-[state=checked]:text-white border-green-600"
+          />
+        </div>
       </div>
-    </DecayCard>
+    </Lanyard>
   );
 };
 

--- a/src/components/reactbits/Lanyard.tsx
+++ b/src/components/reactbits/Lanyard.tsx
@@ -3,19 +3,26 @@ import { cn } from '@/lib/utils';
 
 export interface LanyardProps {
   className?: string;
+  children?: React.ReactNode;
+  cardClassName?: string;
 }
 
-const Lanyard: React.FC<LanyardProps> = ({ className }) => {
+const Lanyard: React.FC<LanyardProps> = ({ className, children, cardClassName }) => {
   return (
     <div className={cn('flex flex-col items-center animate-swing origin-top', className)}>
       <div className="flex gap-1 h-16">
         <div className="w-1 bg-israel-blue rounded" />
         <div className="w-1 bg-israel-blue rounded" />
       </div>
-      <div className="w-24 h-16 bg-white border-2 border-israel-blue rounded shadow-lg overflow-hidden flex flex-col">
+      <div
+        className={cn(
+          'bg-white border-2 border-israel-blue rounded shadow-lg overflow-hidden flex flex-col w-80',
+          cardClassName,
+        )}
+      >
         <div className="h-2 w-full bg-israel-blue" />
-        <div className="flex-1 flex items-center justify-center text-2xl text-israel-blue">
-          ✡
+        <div className="flex-1 flex items-center justify-center p-2">
+          {children ?? <span className="text-2xl text-israel-blue">✡</span>}
         </div>
         <div className="h-2 w-full bg-israel-blue" />
       </div>

--- a/src/components/reactbits/ShinyButton.tsx
+++ b/src/components/reactbits/ShinyButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const ShinyButton: React.FC<ButtonProps> = ({ className, children, ...props }) => (
+  <Button
+    className={cn(
+      'relative overflow-hidden bg-israel-gradient text-white before:absolute before:left-[-100%] before:top-0 before:h-full before:w-[120%] before:bg-white/40 before:rotate-45 hover:before:animate-glare',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </Button>
+);
+
+export default ShinyButton;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import useVisitCount from '@/hooks/useVisitCount';
-import RotatingText from '@/components/reactbits/RotatingText';
 import LanyardHeader from '@/components/LanyardHeader';
-import Lanyard from '@/components/reactbits/Lanyard';
 import JobSourceManager from '@/components/JobSourceManager';
 import { loadSourcesGlobally, saveSourcesGlobally, type JobSource } from '@/services/jobSourcesService';
 import { isUsingDatabase } from '@/services/supabaseClient';
@@ -131,11 +129,6 @@ const Index = () => {
         {/* Header */}
         <div className="text-center mb-12 flex flex-col items-center gap-6">
           <LanyardHeader />
-          <RotatingText
-            texts={["שלחת קורות חיים היום ?"]}
-            className="text-xl font-semibold text-gray-800"
-          />
-          <Lanyard className="mt-4" />
         </div>
 
         {/* Job Sources - Centralized */}


### PR DESCRIPTION
## Summary
- simplify homepage header
- add custom `ShinyButton`
- support custom content in `Lanyard` component
- display title, subtitle, shiny button and checkbox in the swinging card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541ed98e04832693de8a457acdd8f5