### PR TITLE
Fix missing component tagging in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,9 +11,8 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
     componentTagger(),
-  ].filter(Boolean),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- always enable Lovable's `componentTagger` plugin

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854270c41e48326a7014c4f145b847f