### PR TITLE
Fix lov runtime error

### DIFF
--- a/src/lov-guard.ts
+++ b/src/lov-guard.ts
@@ -1,0 +1,14 @@
+// Ensure the global lov object exists to prevent runtime errors from external scripts
+interface LovGlobal {
+  [key: string]: unknown;
+}
+
+declare global {
+  interface Window {
+    lov?: LovGlobal;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.lov = window.lov || {};
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import 'click-spark'
+import './lov-guard'
 
 createRoot(document.getElementById('root')!).render(
   <App />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,18 +4,21 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    componentTagger(),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(() => {
+  const plugins = [react()];
+  if (process.env.LOVABLE_DEV_SERVER === "true") {
+    plugins.push(componentTagger());
+  }
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- ensure global `window.lov` object exists at runtime
- only include lovable-tagger when `LOVABLE_DEV_SERVER=true`
- add guard import to `main.tsx`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685429050a548326925de779b1eb0506